### PR TITLE
adds travis support for PHP 6.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 
 php:
   - 5.6 # lol
+  - 6.0
   #- hhvm
 
 #matrix:


### PR DESCRIPTION
Seems like we should at least have one version of PHP 6.0 tested.

I don't know much about 6.0 but I've read about it in books and PHP conferences for a long time, so I am very excited for its release. 